### PR TITLE
Fix warning in update init script

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
     owner: root
     group: root
     mode: 0755
-  when: "{{ sysfs_uses_old_sysfsutils | bool == true }}"
+  when: sysfs_uses_old_sysfsutils
   notify: restart sysfsutils
   tags:
     - configuration


### PR DESCRIPTION
This fixes the deprecation warning:
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of 
using 
1243
`result|version_compare` use `result is version_compare`. This feature 
will be 
1244
removed in version 2.9. Deprecation warnings can be disabled by setting 
1245
deprecation_warnings=False in ansible.cfg.
1246
 [WARNING]: when statements should not include jinja2 templating 
delimiters
1247
such as {{ }} or {% %}. Found: {{ sysfs_uses_old_sysfsutils | bool == 
true }}